### PR TITLE
Also include outdated casks with auto_updates true or version :latest.

### DIFF
--- a/xbar/brew-updates.1h.rb
+++ b/xbar/brew-updates.1h.rb
@@ -398,7 +398,7 @@ module Brew
     end
 
     def outdated
-      @outdated ||= JSON.parse(cmd(brew_path, 'outdated', '--json'))
+      @outdated ||= JSON.parse(cmd(brew_path, 'outdated', '--greedy', '--json'))
     end
   end
 end


### PR DESCRIPTION
Hi,
I noticed that the outdated casks were not being displayed. I think adding `--greedy` is the solution, or at least that's what has worked for me.

Thank you very much for this repo!